### PR TITLE
Fix path and sample script bug

### DIFF
--- a/src/mujoco-test.py
+++ b/src/mujoco-test.py
@@ -3,6 +3,7 @@ import mujoco.viewer
 
 model = mujoco.MjModel.from_xml_string("<mujoco><worldbody></worldbody></mujoco>")
 data = mujoco.MjData(model)
+
 with mujoco.viewer.launch_passive(model, data) as viewer:
     step = 0
     while viewer.is_running():
@@ -10,3 +11,4 @@ with mujoco.viewer.launch_passive(model, data) as viewer:
         data.ctrl[:] = 0.0  # No control input
         mujoco.mj_step(model, data)
         viewer.sync()
+        viewer.render()

--- a/src/simulate_two_robots.py
+++ b/src/simulate_two_robots.py
@@ -1,9 +1,11 @@
+import os
 import mujoco
 import mujoco.viewer
 import numpy as np
 
-# Load the XML
-model = mujoco.MjModel.from_xml_path("/home/isaacmendez/projects/git/LeRobotWorldwideHackathonSV-team01-pr01/mujoco_models/two_robot_scene.xml")
+# Load the XML using a path relative to this file
+XML_PATH = os.path.join(os.path.dirname(__file__), "../mujoco_models/two_robot_scene.xml")
+model = mujoco.MjModel.from_xml_path(XML_PATH)
 data = mujoco.MjData(model)
 
 # Viewer


### PR DESCRIPTION
## Summary
- load MuJoCo XML using a relative path
- clean up the sample script used to test MuJoCo

## Testing
- `python -m py_compile src/simulate_two_robots.py src/mujoco-test.py src/two_robot_env.py src/test_env.py`

------
https://chatgpt.com/codex/tasks/task_e_684f28794b64832bb70cc5da7de0fc5a