### PR TITLE
test: validate observation shape

### DIFF
--- a/src/test_env.py
+++ b/src/test_env.py
@@ -2,10 +2,12 @@ from two_robot_env import TwoRobotEnv
 
 env = TwoRobotEnv()
 obs = env.reset()
+assert len(obs) == 11
 
-for i in range(1000):
+for i in range(10):
     action = env.action_space.sample()
     obs, reward, done, info = env.step(action)
+    assert len(obs) == 11
     print(f"Step {i}: reward = {reward}")
     # env.render()  ← desactivado por ahora
     if done:


### PR DESCRIPTION
## Summary
- check that the environment observation has length 11 after reset and each step
- reduce test steps to 10 so it runs quickly

## Testing
- `python3 -m py_compile src/test_env.py`
- `python3 -m py_compile src/two_robot_env.py`

------
https://chatgpt.com/codex/tasks/task_e_684f2aee6148832bab863b3e575db841