### PR TITLE
Ensure path resolution in simulate_two_robots

### DIFF
--- a/src/simulate_two_robots.py
+++ b/src/simulate_two_robots.py
@@ -3,8 +3,14 @@ import mujoco
 import mujoco.viewer
 import numpy as np
 
-# Load the XML using a path relative to this file
-XML_PATH = os.path.join(os.path.dirname(__file__), "../mujoco_models/two_robot_scene.xml")
+# Load the XML using a path relative to this file so the script works from any
+# location, matching the approach used in ``two_robot_env.py``.
+XML_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "mujoco_models",
+    "two_robot_scene.xml",
+)
 model = mujoco.MjModel.from_xml_path(XML_PATH)
 data = mujoco.MjData(model)
 


### PR DESCRIPTION
## Summary
- ensure `simulate_two_robots.py` resolves the model file based on its own location

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gym')*

------
https://chatgpt.com/codex/tasks/task_e_684f2c096490832b9c3a5b0604e1c6f4